### PR TITLE
Add Docker Compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+# Filename: docker-compose.yml
+# Instructions for Copilot:
+# 1. Create a `docker-compose.yml` file in the project's root directory.
+# 2. Define a version '3.8' for the compose file.
+# 3. Create a service named `backend`.
+# 4. Configure the `backend` service to build from the `backend` directory.
+#    - The `context` should be `./backend`.
+#    - The `dockerfile` should be `Dockerfile`.
+# 5. Load environment variables for the backend service from the `./backend/.env` file.
+# 6. Map port 8000 of the container to port 8000 on the host machine.
+# 7. Add a `command` to run the FastAPI application using uvicorn:
+#    - It should be `uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload`.
+
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    env_file:
+      - ./backend/.env
+    ports:
+      - "8000:8000"
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload


### PR DESCRIPTION
## Summary
- add compose file for backend service so the project can run via Docker Compose

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68670d937df483269b7373fc7b90d495