### PR TITLE
Add environment example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration
+# Copy this file to `.env` and fill in your local values.
+
+# Backend settings
+SECRET_KEY=changeme
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+BACKEND_CORS_ORIGINS=["http://localhost:3000"]
+
+# Gemini API key used by the frontend
+GEMINI_API_KEY=your-gemini-key

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.example` to `.env` and update the values (e.g. set your `GEMINI_API_KEY`).
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- add `.env.example` showing required environment variables
- update README on how to copy `.env.example` for local runs

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68670d976084832690160419f682d79d