### PR TITLE
Add Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,22 @@ This contains everything you need to run your app locally.
 2. Copy `.env.example` to `.env` and update the values (e.g. set your `GEMINI_API_KEY`).
 3. Run the app:
    `npm run dev`
+
+## Run with Docker Compose
+
+**Prerequisites:** Docker and Python 3.9+
+
+1. Copy `.env.example` to both `.env` and `backend/.env`:
+   ```sh
+   cp .env.example .env
+   cp .env.example backend/.env
+   ```
+2. Start all services:
+   ```sh
+   docker-compose up --build
+   ```
+   The API will be available at `http://localhost:8000`.
+3. To run the unit tests inside the backend container:
+   ```sh
+   docker-compose exec backend pytest
+   ```


### PR DESCRIPTION
## Summary
- document how to run the stack with Docker Compose
- mention copying `.env.example` to both `.env` and `backend/.env`
- describe how to run unit tests inside the backend container

## Testing
- `pytest -q` *(fails: DNS resolution failure)*

------
https://chatgpt.com/codex/tasks/task_e_6867198a882883268a6c2cfcc134bc94